### PR TITLE
Added option to save unsynced lyrics

### DIFF
--- a/lyricy/__init__.py
+++ b/lyricy/__init__.py
@@ -43,13 +43,16 @@ class Lyrics(BaseLyrics):
         with open(path, "w") as file:
             file.write(self.lyrics)
 
-    def add_to_track(self, path: str):
+    def add_to_track(self, path: str, without_lrc_tags = False):
         """
         Add the lyrics to track metadata
         `path`: path of the track
         """
         f = music_tag.load_file(path)
-        f["lyrics"] = self.lyrics
+        if without_lrc_tags:
+            f["lyrics"] = self.lyrics_without_lrc_tags
+        else:
+            f["lyrics"] = self.lyrics
         f.save()
 
 


### PR DESCRIPTION
## What I changed

Added a boolean parameter in '*lyricy / \_\_init\_\_.py / class Lyrics / def add_to_track()*' to choose whether to add the lyrics to the track **without any lrc** tags or **with lrc tags**. The function will then simply check for the parameter and add the lyrics accordingly.

## Why I changed

I used this tool to add lyrics to my offline songs, but for some reason I wanted only unsynced lyrics. That's why the change.

> This is my first-time-contributing. Feedback would be appreciated about whether the modified code is enough for contribution or should i need to learn more.